### PR TITLE
docs: Add GitHub repo URL to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.2"
 edition = "2021"
 description = "A cross platform snake game running in the terminal"
 license = "MIT"
+repository = "https://github.com/RiccardoSegala04/snake-tui"
 
 
 [dependencies]


### PR DESCRIPTION
This makes it easier to go from the crates.io page to the GitHub repo, without having to dig too hard.